### PR TITLE
Improve python -> libc interface

### DIFF
--- a/libc.p64
+++ b/libc.p64
@@ -1,0 +1,5 @@
+def main():
+   fp = fopen('myfile', 'w')
+   fputs(r'hello world!\n', fp)
+   fclose(fp)
+   exit(-1)


### PR DESCRIPTION
Stack align libc printf and scanf calls.  Add synthetic python adr(x) function to pass &x to libc functions.